### PR TITLE
Update table

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,11 +113,11 @@
 					<td>A work stealing fork-join threadpool supporting parallel iterators</td>
 					<td class=almost>Functional, though still prone to change</td>
 				</tr>
-<tr>
-  <td><a href="https://github.com/willi-kappler/mandel-rust">mandel-rust</a></td>
-  <td>A small mandelbrot demo showing how to use some parallelization crates</td>
-  <td class=almost>Functional, though still prone to change</td>
-</tr>
+				<tr>
+					<td><a href="https://github.com/willi-kappler/mandel-rust">mandel-rust</a></td>
+					<td>A small mandelbrot demo showing how to use some parallelization crates</td>
+					<td class=almost>Functional, though still prone to change</td>
+				</tr>
 			</tbody>
 		</table>
 

--- a/index.html
+++ b/index.html
@@ -67,8 +67,8 @@
 					<td class=almost>Functional, but under active development</td>
 				</tr>
 				<tr>
-					<td rowspan=9 class=done title=Almost></td>
-					<td rowspan=9>Other</td>
+					<td rowspan=10 class=done title=Almost></td>
+					<td rowspan=10>Other</td>
 					<td><a href=https://github.com/aturon/crossbeam>crossbeam</a></td>
           <td>Support for parallelism and low-level concurrency in Rust</td>
 					<td class=almost>Functional, though still prone to change</td>
@@ -109,10 +109,15 @@
 					<td class=almost>Functional, but rarely tested and still prone to change</td>
 				</tr>
 				<tr>
-					<td><a href=https://github.com/huonw/simple_parallel>simple_parallel</a></td>
-					<td>An easy way to add coarse-grained parallelism</td>
+					<td><a href="https://github.com/rphmeier/jobsteal">Jobsteal</a></td>
+					<td>A work stealing fork-join threadpool supporting parallel iterators</td>
 					<td class=almost>Functional, though still prone to change</td>
 				</tr>
+<tr>
+  <td><a href="https://github.com/willi-kappler/mandel-rust">mandel-rust</a></td>
+  <td>A small mandelbrot demo showing how to use some parallelization crates</td>
+  <td class=almost>Functional, though still prone to change</td>
+</tr>
 			</tbody>
 		</table>
 


### PR DESCRIPTION
Hi there,

I've updated the HTML table:
- Removed simple_parallel, it seems unmaintained and does not compile with newer version of crossbeam.
- Instead I've added jobsteal as an alternative.
- I've also added the mandel-rust demo (that I wrote) which shows how to use some of the crates mentioned on this website
